### PR TITLE
ssh/tunnel: add ssh tunnel that implement net.Conn

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Package sshtools provides a wrapper around SSH client with the following feature
 
 * Context aware (dial and execution),
 * Keepalive enabled,
-* Can copy files using SCP.
+* Can copy files using SCP,
+* Provide SSH tunneling for net.Conn (HTTP+SSH).
 
 ## License
 

--- a/doc.go
+++ b/doc.go
@@ -6,4 +6,5 @@ package sshtools
 //
 // * Context aware (dial and execution),
 // * Keepalive enabled,
-// * Can copy files using SCP.
+// * Can copy files using SCP,
+// * Provide SSH tunneling for net.Conn (HTTP+SSH).

--- a/httpshell/conn.go
+++ b/httpshell/conn.go
@@ -23,6 +23,8 @@ type proxyConn struct {
 	free func()
 }
 
+var _ net.Conn = (*proxyConn)(nil)
+
 // newProxyConn opens a new session and start the shell. When the connection is
 // closed the client is closed and the free function is called.
 func newProxyConn(client *ssh.Client, stderr io.Writer, free func()) (*proxyConn, error) {

--- a/httpshell/dialer.go
+++ b/httpshell/dialer.go
@@ -66,7 +66,7 @@ func (p *Dialer) DialContext(ctx context.Context, network, addr string) (conn ne
 
 	pconn, err := newProxyConn(client, &logStderr{host: host, logger: p.logger}, free)
 	if err != nil {
-		client.Close()
+		_ = client.Close()
 		return nil, errors.Wrap(err, "ssh: failed to connect")
 	}
 
@@ -75,7 +75,7 @@ func (p *Dialer) DialContext(ctx context.Context, network, addr string) (conn ne
 	// Init SSH keepalive if needed
 	if p.config.KeepaliveEnabled() {
 		p.logger.Println("Starting ssh KeepAlives", "host", host)
-		go sshtools.StartKeepalive(client, p.config.ServerAliveInterval, p.config.ServerAliveCountMax, keepaliveDone)
+		go sshtools.KeepAlive(client, p.config.ServerAliveInterval, p.config.ServerAliveCountMax, keepaliveDone)
 	}
 
 	return pconn, nil

--- a/httpshell/listener_test.go
+++ b/httpshell/listener_test.go
@@ -20,7 +20,7 @@ func TestListenerAcceptOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 	time.AfterFunc(50*time.Millisecond, func() {
-		conn.Close()
+		_ = conn.Close()
 	})
 	_, err = l.Accept()
 	if err != io.EOF {

--- a/proxydialer.go
+++ b/proxydialer.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2019 ScyllaDB
+
+package sshtools
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+// ProxyDialer is a dialler that allows for proxying connections over SSH.
+type ProxyDialer struct {
+	config Config
+	dial   DialContextFunc
+
+	OnDial      func(host string, err error)
+	OnConnClose func(host string)
+}
+
+// NewProxyDialer creates an instance of a ProxyDialer that is capable of
+// setting up an ssh tunnels.
+func NewProxyDialer(config Config, dial DialContextFunc) *ProxyDialer {
+	return &ProxyDialer{config: config, dial: dial}
+}
+
+// DialContext dials to addr (HOST:PORT) and establishes an SSH connection
+// to HOST and then proxies the connection to localhost:PORT.
+func (pd *ProxyDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	var tun Tunnel
+
+	host, port, err := net.SplitHostPort(addr)
+	defer func() {
+		if pd.OnDial != nil {
+			pd.OnDial(host, err)
+		}
+	}()
+
+	tun.client, err = pd.dial(ctx, network,
+		net.JoinHostPort(host, fmt.Sprint(pd.config.Port)), &pd.config.ClientConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "ssh: dial failed")
+	}
+
+	for _, h := range []string{"0.0.0.0", host} {
+		// This is a local dial and should not hang but if it does http client
+		// would end up with "context deadline exceeded" error.
+		// To be fixed when used with something else then http client.
+		tun.Conn, err = tun.client.Dial(network, net.JoinHostPort(h, port))
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		_ = tun.client.Close()
+		return nil, errors.Wrap(err, "ssh: remote dial failed")
+	}
+
+	tun.free = func() {
+		if pd.OnConnClose != nil {
+			pd.OnConnClose(host)
+		}
+	}
+
+	if pd.config.KeepaliveEnabled() {
+		tun.done = make(chan struct{})
+		go KeepAlive(tun.client, pd.config.ServerAliveInterval, pd.config.ServerAliveCountMax, tun.done)
+	}
+
+	return tun, nil
+}

--- a/tunnel.go
+++ b/tunnel.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 ScyllaDB
+
+package sshtools
+
+import (
+	"net"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// Tunnel holds an ssh tunnel to some resource on remote machine
+type Tunnel struct {
+	net.Conn
+
+	client *ssh.Client
+
+	done chan struct{}
+	free func()
+}
+
+var _ net.Conn = (*Tunnel)(nil)
+
+// Client returns ssh client instance.
+func (c Tunnel) Client() *ssh.Client {
+	return c.client
+}
+
+// Close closes the connection and frees the associated resources.
+func (c Tunnel) Close() error {
+	defer c.free()
+
+	if c.done != nil {
+		close(c.done)
+	}
+
+	// Close closes the underlying network connection.
+	return c.client.Close()
+}


### PR DESCRIPTION
SSH tunnel implementing net.Conn provides a means for having HTTP+SSH clients.